### PR TITLE
Fix install-all command

### DIFF
--- a/lib/options.sh
+++ b/lib/options.sh
@@ -32,7 +32,8 @@ process_option() {
       caffeinate_machine
       bin/apply_basic_settings
       bin/install_dev_tools
-      bin/install_homebrew
+      bin/install_homebrew_formulas
+      bin/install_homebrew_casks
       bin/install_app_store
       bin/install_applications
       bin/install_extensions


### PR DESCRIPTION
The install-all command does not reflect that the `bin/install_homebrew` file was split into `bin/install_homebrew_formulas` and `bin/install_homebrew_casks`, and therefore fails to install.

## Overview
The use of the "install everything" command will fail without this change.
